### PR TITLE
fix: use django's auth implementation and add redirects to login page

### DIFF
--- a/analyze/templates/analyze/layout.html
+++ b/analyze/templates/analyze/layout.html
@@ -11,7 +11,7 @@
   <script src="{% static 'analyze/script.js' %}"></script>
 </head>
 <body>
-    <nav class="navbar navbar-expand-sm bg-body-tertiary">
+  <nav class="navbar navbar-expand-sm bg-body-tertiary">
     <div class="container-fluid">
       <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
@@ -33,7 +33,14 @@
           </li>
         </ul>
       </div>
+      {% if not user.is_authenticated %}
       <a class="btn btn-outline-success me-2" href="{% url 'login' %}" role="button">Sign In</a>
+      {% else %}
+      <span class="navbar-text me-2">Signed in as {{ user }}</span>
+      <form action="{% url 'logout'%}" method="post">
+      {% csrf_token %}
+      <input class="btn btn-outline-danger me-2" type="submit" value="Sign Out">
+      {% endif %}
     </div>
   </nav>
 	{% block body %}

--- a/analyze/templates/analyze/layout.html
+++ b/analyze/templates/analyze/layout.html
@@ -33,7 +33,7 @@
           </li>
         </ul>
       </div>
-      <a class="btn btn-outline-success me-2" href="{% url 'users:login' %}" role="button">Sign In</a>
+      <a class="btn btn-outline-success me-2" href="{% url 'login' %}" role="button">Sign In</a>
     </div>
   </nav>
 	{% block body %}

--- a/analyze/views.py
+++ b/analyze/views.py
@@ -1,10 +1,11 @@
 from django.shortcuts import render
-from django.db.models import Count
 from symptoms.models import Symptoms, SymptomsLog
 from food.models import Food, FoodLog
 import pandas as pd
+from django.contrib.auth.decorators import login_required
 
 # Create your views here.
+@login_required
 def index(request):
     symptoms = Symptoms.objects.all()
     symptoms_history = SymptomsLog.objects.filter(user=request.user)

--- a/food/templates/food/layout.html
+++ b/food/templates/food/layout.html
@@ -32,7 +32,7 @@
           </li>
         </ul>
       </div>
-      <a class="btn btn-outline-success me-2" href="{% url 'users:login' %}" role="button">Sign In</a>
+      <a class="btn btn-outline-success me-2" href="{% url 'login' %}" role="button">Sign In</a>
     </div>
   </nav>
   {% block body %}

--- a/food/templates/food/layout.html
+++ b/food/templates/food/layout.html
@@ -32,7 +32,14 @@
           </li>
         </ul>
       </div>
+      {% if not user.is_authenticated %}
       <a class="btn btn-outline-success me-2" href="{% url 'login' %}" role="button">Sign In</a>
+      {% else %}
+      <span class="navbar-text me-2">Signed in as {{ user }}</span>
+      <form action="{% url 'logout'%}" method="post">
+      {% csrf_token %}
+      <input class="btn btn-outline-danger me-2" type="submit" value="Sign Out">
+      {% endif %}
     </div>
   </nav>
   {% block body %}

--- a/food/views.py
+++ b/food/views.py
@@ -1,10 +1,12 @@
 from django.shortcuts import render
-from django.http import HttpResponse, HttpResponseRedirect
+from django.http import HttpResponseRedirect
 from django.urls import reverse
 from .models import Food, FoodLog
 from datetime import datetime, timedelta, timezone
+from django.contrib.auth.decorators import login_required
 
 # Create your views here.
+@login_required
 def index(request):
     registered_foods = Food.objects.all()
     food_history = FoodLog.objects.filter(user=request.user)

--- a/food_diary/settings.py
+++ b/food_diary/settings.py
@@ -127,4 +127,10 @@ STATIC_URL = 'static/'
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
-AUTH_USER_MODEL = "users.User" 
+AUTH_USER_MODEL = "users.User"
+
+LOGIN_REDIRECT_URL = "/"
+
+LOGOUT_REDIRECT_URL = "/"
+
+LOGIN_URL = "users:login"

--- a/food_diary/settings.py
+++ b/food_diary/settings.py
@@ -132,5 +132,3 @@ AUTH_USER_MODEL = "users.User"
 LOGIN_REDIRECT_URL = "/"
 
 LOGOUT_REDIRECT_URL = "/"
-
-LOGIN_URL = "users:login"

--- a/food_diary/urls.py
+++ b/food_diary/urls.py
@@ -20,7 +20,8 @@ from django.urls import path, include
 urlpatterns = [
     path('admin/', admin.site.urls),
     path("food/", include("food.urls")),
-    path("users/", include("django.contrib.auth.urls")),
+    path("users/", include("users.urls")),
+    path("accounts/", include("django.contrib.auth.urls")),
     path("symptoms/", include("symptoms.urls")),
     path("analyze/", include("analyze.urls")),
     path("", include("homepage.urls")),

--- a/food_diary/urls.py
+++ b/food_diary/urls.py
@@ -20,7 +20,7 @@ from django.urls import path, include
 urlpatterns = [
     path('admin/', admin.site.urls),
     path("food/", include("food.urls")),
-    path("users/", include("users.urls")),
+    path("users/", include("django.contrib.auth.urls")),
     path("symptoms/", include("symptoms.urls")),
     path("analyze/", include("analyze.urls")),
     path("", include("homepage.urls")),

--- a/homepage/templates/homepage/layout.html
+++ b/homepage/templates/homepage/layout.html
@@ -32,7 +32,7 @@
           </li>
         </ul>
       </div>
-      <a class="btn btn-outline-success me-2" href="{% url 'users:login' %}" role="button">Sign In</a>
+      <a class="btn btn-outline-success me-2" href="{% url 'login' %}" role="button">Sign In</a>
     </div>
   </nav>
   {% block body %}

--- a/homepage/templates/homepage/layout.html
+++ b/homepage/templates/homepage/layout.html
@@ -32,7 +32,14 @@
           </li>
         </ul>
       </div>
+      {% if not user.is_authenticated %}
       <a class="btn btn-outline-success me-2" href="{% url 'login' %}" role="button">Sign In</a>
+      {% else %}
+      <span class="navbar-text me-2">Signed in as {{ user }}</span>
+      <form action="{% url 'logout'%}" method="post">
+      {% csrf_token %}
+      <input class="btn btn-outline-danger me-2" type="submit" value="Sign Out">
+      {% endif %}
     </div>
   </nav>
   {% block body %}

--- a/homepage/views.py
+++ b/homepage/views.py
@@ -2,4 +2,6 @@ from django.shortcuts import render
 
 # Create your views here.
 def index(request):
-   return render(request, "homepage/index.html")
+   return render(request, "homepage/index.html", {
+      "user": request.user,
+   })

--- a/symptoms/templates/symptoms/layout.html
+++ b/symptoms/templates/symptoms/layout.html
@@ -32,7 +32,7 @@
           </li>
         </ul>
       </div>
-      <a class="btn btn-outline-success me-2" href="{% url 'users:login' %}" role="button">Sign In</a>
+      <a class="btn btn-outline-success me-2" href="{% url 'login' %}" role="button">Sign In</a>
     </div>
   </nav>
 	{% block body %}

--- a/symptoms/templates/symptoms/layout.html
+++ b/symptoms/templates/symptoms/layout.html
@@ -32,7 +32,14 @@
           </li>
         </ul>
       </div>
+      {% if not user.is_authenticated %}
       <a class="btn btn-outline-success me-2" href="{% url 'login' %}" role="button">Sign In</a>
+      {% else %}
+      <span class="navbar-text me-2">Signed in as {{ user }}</span>
+      <form action="{% url 'logout'%}" method="post">
+      {% csrf_token %}
+      <input class="btn btn-outline-danger me-2" type="submit" value="Sign Out">
+      {% endif %}
     </div>
   </nav>
 	{% block body %}

--- a/symptoms/views.py
+++ b/symptoms/views.py
@@ -3,8 +3,10 @@ from django.http import  HttpResponseRedirect
 from django.urls import reverse
 from .models import Symptoms, SymptomsLog
 from datetime import datetime, timedelta, timezone
+from django.contrib.auth.decorators import login_required
 
 # Create your views here.
+@login_required
 def index(request):
     registered_symptoms = Symptoms.objects.all()
     symptoms_history = SymptomsLog.objects.filter(user=request.user)

--- a/users/templates/registration/login.html
+++ b/users/templates/registration/login.html
@@ -14,9 +14,4 @@
     <input type="submit", value="Login">
     <input type="hidden", name="next" value="{{ next }}">
   </form>
-
-  <form action="{% url 'logout'%}" method="post">
-    {% csrf_token %}
-    <input type="submit" value="Logout">
-  </form>
 {% endblock %}

--- a/users/templates/registration/login.html
+++ b/users/templates/registration/login.html
@@ -1,12 +1,10 @@
 {% extends "users/layout.html" %}
 
 {% block body %}
-  {% if messages %}
-		{% for message in messages %}
-      <div>{{ message }}</div>
-		{% endfor %}
+  {% if request.GET.next %}
+    <h2 class="signin-message">Please sign in to continue</h2>
   {% endif %}
-
+  
   <form action="{% url 'login' %}" method="post">
     {% csrf_token %}
     <input type="text", name="username", placeholder="Username">

--- a/users/templates/registration/login.html
+++ b/users/templates/registration/login.html
@@ -7,10 +7,16 @@
 		{% endfor %}
   {% endif %}
 
-  <form action="{% url 'users:login' %}" method="post">
+  <form action="{% url 'login' %}" method="post">
     {% csrf_token %}
     <input type="text", name="username", placeholder="Username">
     <input type="password", name="password", placeholder="Password">
     <input type="submit", value="Login">
+    <input type="hidden", name="next" value="{{ next }}">
+  </form>
+
+  <form action="{% url 'logout'%}" method="post">
+    {% csrf_token %}
+    <input type="submit" value="Logout">
   </form>
 {% endblock %}

--- a/users/templates/users/login.html
+++ b/users/templates/users/login.html
@@ -1,14 +1,16 @@
 {% extends "users/layout.html" %}
 
 {% block body %}
-    {% if message %}
-        <div>{{ message }}</div>
-    {% endif %}
+  {% if messages %}
+		{% for message in messages %}
+      <div>{{ message }}</div>
+		{% endfor %}
+  {% endif %}
 
-    <form action="{% url 'users:login' %}" method="post">
-        {% csrf_token %}
-        <input type="text", name="username", placeholder="Username">
-        <input type="password", name="password", placeholder="Password">
-        <input type="submit", value="Login">
-    </form>
+  <form action="{% url 'users:login' %}" method="post">
+    {% csrf_token %}
+    <input type="text", name="username", placeholder="Username">
+    <input type="password", name="password", placeholder="Password">
+    <input type="submit", value="Login">
+  </form>
 {% endblock %}

--- a/users/urls.py
+++ b/users/urls.py
@@ -3,7 +3,4 @@ from . import views
 
 app_name = "users"
 urlpatterns = [
-    path("", views.index, name="index"),
-    path("login", views.login_view, name="login"),
-    path("logout", views.logout_view, name="logout"),
 ]

--- a/users/views.py
+++ b/users/views.py
@@ -4,32 +4,3 @@ from django.urls import reverse
 from django.contrib.auth import authenticate, login, logout
 
 # Create your views here.
-def index(request):
-    # Redirect to login page if user not signed in
-    if not request.user.is_authenticated:
-        return HttpResponseRedirect(reverse("users:login"))
-    return render(request, "users/user.html")
-
-
-def login_view(request):
-    if request.method == "POST":
-        username = request.POST["username"]
-        password = request.POST["password"]
-
-        user = authenticate(request, username=username, password=password)
-
-        if user:
-            login(request, user)
-            return HttpResponseRedirect(reverse("users:index"))
-        else:
-            return render(request, "users/login.html", {
-                "message": "Wrong Username/Password"
-            })
-    return render(request, "users/login.html")
-
-
-def logout_view(request):
-    logout(request)
-    return render(request, "users/login.html", {
-        "message": "Logged Out",
-    })


### PR DESCRIPTION
- use django's authentication implementation instead of custom auth implementation
- use login_required decorator from django's authentication to redirect users to login pages for food, symptoms and analyze app
- show sign in button on navbar when not signed in
- show "signed in as user" and sign out button on navbar when signed in
- show "please sign in to continue" message in login page if user was redirected there