### PR TITLE
fix: remove redundant plugins in charts and add fill to symptoms chart

### DIFF
--- a/analyze/static/analyze/script.js
+++ b/analyze/static/analyze/script.js
@@ -22,7 +22,8 @@ document.addEventListener('DOMContentLoaded', function() {
       symDataset.push(
         {
           label: key,
-          data: value
+          data: value,
+          fill: true
         })
     }
 
@@ -54,7 +55,6 @@ document.addEventListener('DOMContentLoaded', function() {
             }
           },
           x: {
-            stacked: true,
             title: {
               display: true,
               text: 'Date'

--- a/analyze/static/analyze/script.js
+++ b/analyze/static/analyze/script.js
@@ -36,9 +36,6 @@ document.addEventListener('DOMContentLoaded', function() {
       options: {
         maintainAspectRatio: false,
         plugins: {
-          colorschemes: {
-                scheme: 'tableau.Tableau20'
-            },
           title: {
             display: true,
             text: 'Occurrences of Symptoms over time'
@@ -76,7 +73,6 @@ document.addEventListener('DOMContentLoaded', function() {
         options: {
           maintainAspectRatio: false,
           plugins: {
-            colorschemes: 'tableau.Tableau20',
             title: {
               display: true,
               text: 'Food history over time'


### PR DESCRIPTION
Without the fill, it is not clear that symptoms line chart is a stacked line chart